### PR TITLE
Removes unnecessary dependencies on sed, cp, and chmod

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,8 +26,6 @@
 
 # CMAKE build file for GtkFortran
 
-include_directories("/usr/include")
-include_directories("/usr/local/include")
 include_directories("${CMAKE_BINARY_DIR}/src")
 include_directories(${GTK_INCLUDES})
 
@@ -57,7 +55,7 @@ if (NOT NO_BUILD_EXAMPLES)
   if (UNIX)
     add_custom_command(
       OUTPUT gtkbuilder.glade
-      COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/gtkbuilder.glade ${CMAKE_CURRENT_BINARY_DIR}/gtkbuilder.glade
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gtkbuilder.glade ${CMAKE_CURRENT_BINARY_DIR}/gtkbuilder.glade
       DEPENDS  ${CMAKE_CURRENT_SOURCE_DIR}/gtkbuilder.glade
       )
   endif()

--- a/plplot/CMakeLists.txt
+++ b/plplot/CMakeLists.txt
@@ -25,7 +25,6 @@
 # set(sources
 #   "plplot_extra.f90")
 
-include_directories("/usr/include")
 #include_directories(${PLPLOT_INCLUDES})
 include_directories("${CMAKE_BINARY_DIR}/plplot")
 include_directories("${CMAKE_BINARY_DIR}/src")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,10 +54,7 @@ set(sources
 	"gdk-pixbuf-hl.f90"
 	"gdkevents-auto2.f90")
 
-include_directories("/usr/include")
 include_directories(${GTK_INCLUDES})
-include_directories("/usr/local/include")
-include_directories("/usr/local/include/gtk-2-fortran")
 
 add_library(gtk-fortran_static STATIC ${sources})
 add_library(gtk-fortran_shared SHARED ${sources})
@@ -77,48 +74,45 @@ SOVERSION "0.1")
 
 # Does pkg-config have an equivalent in Windows? If so, then please
 # add a suitable generator and installation.
-add_custom_command(
-  OUTPUT gtk-2-fortran.pc
-  COMMAND sed -e s+@prefix@+${CMAKE_INSTALL_PREFIX}+ -e s/@version@/${CPACK_PACKAGE_VERSION}/ ${CMAKE_CURRENT_SOURCE_DIR}/gtk-2-fortran.pc.in > ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran.pc
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gtk-2-fortran.pc.in
-  )
-add_custom_target(pkgconfig ALL DEPENDS "gtk-2-fortran.pc")
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/gtk-2-fortran.pc.in GTK2PCIN)
+string(REPLACE "@prefix@" "${CMAKE_INSTALL_PREFIX}" GTK2PCOUT1 "${GTK2PCIN}")
+string(REPLACE "@version@" "${CPACK_PACKAGE_VERSION}" GTK2PCOUT2 "${GTK2PCOUT1}")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran.pc "${GTK2PCOUT2}")
+add_custom_target(pkgconfig ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran.pc)
 
 # The USE generator system.
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/usemodules.pl USERMODULE_IN)
+string(REPLACE "@PREFIX@" "${CMAKE_INSTALL_PREFIX}" USERMODULE_OUT1 "${USERMODULE_IN}")
+string(REPLACE "@SHARE@" "${CMAKE_INSTALL_DATAROOTDIR}" USERMODULE_OUT2 "${USERMODULE_OUT1}")
+string(REPLACE "@GTK@" "2" USERMODULE_OUT3 "${USERMODULE_OUT2}")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-modscan "${USERMODULE_OUT3}")
+
 add_custom_command(
-  OUTPUT gtk-2-fortran-modscan
-  COMMAND sed -e s+@PREFIX@+${CMAKE_INSTALL_PREFIX}+ -e s/@GTK@/2/ -e s+@SHARE@+${CMAKE_INSTALL_DATAROOTDIR}+ ${CMAKE_CURRENT_SOURCE_DIR}/usemodules.pl > ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-modscan
-  COMMAND chmod a+x ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-modscan
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/usemodules.pl
-)
-add_custom_command(
-  OUTPUT gtk-2-fortran-index.csv
-  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/gtk-fortran-index.csv ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-index.csv
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-index.csv
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gtk-fortran-index.csv ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-index.csv
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gtk-fortran-index.csv
 )
 add_custom_command(
-  OUTPUT gtk-2-enumerators.lis
-  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/gtk-enumerators.lis ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-enumerators.lis
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-enumerators.lis
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/gtk-enumerators.lis ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-enumerators.lis
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gtk-enumerators.lis
 )
 
-add_custom_target(usemodules ALL DEPENDS gtk-2-fortran-modscan
-  gtk-2-fortran-index.csv gtk-2-enumerators.lis)
+add_custom_target(usemodules ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-modscan
+  ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-index.csv ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-enumerators.lis)
 
 # Man page(s)
-add_custom_command(
-  OUTPUT gtk-2-fortran-modscan.1
-  COMMAND sed -e s/@GTK@/2/  ${CMAKE_CURRENT_SOURCE_DIR}/gtk-fortran-modscan.man > ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-modscan.1
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gtk-fortran-modscan.man
-)
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/gtk-fortran-modscan.man MODSCAN_IN)
+string(REPLACE "@GTK@" "2" MODSCAN_OUT "${MODSCAN_IN}")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-modscan.1 "${MODSCAN_OUT}")
 
-add_custom_target(manpage ALL DEPENDS gtk-2-fortran-modscan.1)
+add_custom_target(manpage ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-modscan.1)
 
 if (CMAKE_HOST_WIN32)
   install(TARGETS gtk-fortran_static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  install(TARGETS gtk-fortran_shared LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(TARGETS gtk-fortran_shared LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 else()
   install(TARGETS gtk-fortran_static ARCHIVE DESTINATION 
     ${CMAKE_INSTALL_LIBDIR})
@@ -159,6 +153,7 @@ install(FILES
 install(PROGRAMS
   "${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-modscan"
   DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PERMISSIONS WORLD_EXECUTE
 )
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/gtk-2-fortran-index.csv"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,10 +25,8 @@
 
 
 add_custom_command(
-  OUTPUT run_all
-  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/run_all.pl ${CMAKE_CURRENT_BINARY_DIR}/run_all
-  COMMAND chmod a+x ${CMAKE_CURRENT_BINARY_DIR}/run_all
-  DEPENDS  ${CMAKE_CURRENT_SOURCE_DIR}/run_all.pl
-  )
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/run_all
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/run_all.pl ${CMAKE_CURRENT_BINARY_DIR}/run_all
+)
 
-add_custom_target(tester ALL DEPENDS "run_all")
+add_custom_target(tester ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/run_all)


### PR DESCRIPTION
There are a number of CMake custom tasks that will cause _make_ to fail on Windows after constructing MinGW makefiles.  Specifically, the tasks rely on UNIX-y commands: cp, sed, and chmod.  Most of the tasks are unnecessary, however.

The _cp_ tasks should be using _${CMAKE_COMMAND} -E copy_ per the CMake documentation for cross-platform support.

The _sed_ tasks are straightforward text replacements.  CMake can handle these using _STRING_ commands instead.

The _chmod_ tasks are somewhat more problematic.  The _gtk-2-fortran-modscan_ executable can be set with the proper permissions by setting _WORLD_EXECUTE_ during install rather than using _chmod_.  The _run_all_ script in _tests_ is no longer marked as executable, however, as it isn't installed.  It's a bit of a problem.

These changes shouldn't adversely affect any other platforms.
