### PR TITLE
Fix #79 .

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,12 +40,12 @@ if (NOT NO_BUILD_EXAMPLES)
 
   add_executable(gtkbuilder "gtkbuilder.f90")
   target_link_libraries(gtkbuilder gtk-fortran_static ${GTK_LIBRARIES})
-  set_target_properties(gtkbuilder PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtkbuilder/ )
+  set_target_properties(gtkbuilder PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtkbuilder_mod/ )
   # This test is excluded because the directories don't match up.
   #add_test(gtkbuilder gtkbuilder)
   add_executable(gtkbuilder2 "gtkbuilder2.f90" "gtkbuilder.glade")
   target_link_libraries(gtkbuilder2 gtk-fortran_static ${GTK_LIBRARIES})
-  set_target_properties(gtkbuilder2 PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtkbuilder2/ )
+  set_target_properties(gtkbuilder2 PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtkbuilder2_mod/ )
   # This test is excluded because the directories don't match up.
   # add_test(gtkbuilder2 gtkbuilder2)
 
@@ -77,7 +77,7 @@ if (NOT NO_BUILD_EXAMPLES)
           mandelbrot_pixbuf_zoom menu notebooks ${gio_demo_example} tests)
     add_executable(${example} "${example}.f90")
     target_link_libraries(${example} gtk-fortran_static ${GTK_LIBRARIES})
-    set_target_properties(${example} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${example}/ )
+    set_target_properties(${example} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${example}_mod/ )
     add_test(${example} ./${example})
   endforeach(example)
 endif(NOT NO_BUILD_EXAMPLES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 # CMAKE build file for gtk-fortran
 
-include_directories("${CMAKE_BINARY_DIR}/src")
+include_directories("${CMAKE_BINARY_DIR}/src/modules_static")
 include_directories(${GTK_INCLUDES})
 
 if (NOT NO_BUILD_EXAMPLES)
@@ -40,10 +40,12 @@ if (NOT NO_BUILD_EXAMPLES)
 
   add_executable(gtkbuilder "gtkbuilder.f90")
   target_link_libraries(gtkbuilder gtk-fortran_static ${GTK_LIBRARIES})
+  set_target_properties(gtkbuilder PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtkbuilder/ )
   # This test is excluded because the directories don't match up.
   #add_test(gtkbuilder gtkbuilder)
   add_executable(gtkbuilder2 "gtkbuilder2.f90" "gtkbuilder.glade")
   target_link_libraries(gtkbuilder2 gtk-fortran_static ${GTK_LIBRARIES})
+  set_target_properties(gtkbuilder2 PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtkbuilder2/ )
   # This test is excluded because the directories don't match up.
   # add_test(gtkbuilder2 gtkbuilder2)
 
@@ -75,6 +77,7 @@ if (NOT NO_BUILD_EXAMPLES)
           mandelbrot_pixbuf_zoom menu notebooks ${gio_demo_example} tests)
     add_executable(${example} "${example}.f90")
     target_link_libraries(${example} gtk-fortran_static ${GTK_LIBRARIES})
+    set_target_properties(${example} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${example}/ )
     add_test(${example} ./${example})
   endforeach(example)
 endif(NOT NO_BUILD_EXAMPLES)

--- a/sketcher/CMakeLists.txt
+++ b/sketcher/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 # CMAKE build file for gtkf-sketcher
 
-include_directories("${CMAKE_BINARY_DIR}/src")
+include_directories("${CMAKE_BINARY_DIR}/src/modules_static")
 include_directories(${GTK_INCLUDES})
 
 add_executable(gtkf-sketcher "gtkf-sketcher.f90")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,10 +80,13 @@ gtk-fortran_shared PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 
 set_target_properties(gtk-fortran_static gtk-fortran_shared PROPERTIES
 VERSION "0.1")
-set_target_properties(gtk-fortran_static
-gtk-fortran_shared PROPERTIES VERSION "0.1")
 set_target_properties(gtk-fortran_static gtk-fortran_shared PROPERTIES
 SOVERSION "0.1")
+
+set_target_properties(gtk-fortran_static PROPERTIES
+Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules_static/ )
+set_target_properties(gtk-fortran_shared PROPERTIES
+Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules_shared/ )
 
 # Does pkg-config have an equivalent in Windows? If so, then please
 # add a suitable generator and installation.
@@ -137,35 +140,9 @@ else()
     ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/atk.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/cairo.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gdk.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gdk_pixbuf.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/g.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_container.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_button.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_entry.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_tree.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_menu.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_combobox.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_spin_slider.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_chooser.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_dialog.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_progress.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_accelerator.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_infobar.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_assistant.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_hl_misc.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_draw_hl.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gdk_pixbuf_hl.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_sup.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/pango.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gdk_events.mod"
-    "${CMAKE_CURRENT_BINARY_DIR}/gtk_os_dependent.mod"
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gtk-${GTKv}-fortran
+install(DIRECTORY
+  ${CMAKE_CURRENT_BINARY_DIR}/modules_shared/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gtk-${GTKv}-fortran
 )
 
 install(PROGRAMS


### PR DESCRIPTION
Building static and shared libraries similtaneously have made them overwrote each other's modules.
For the examples they have modules with same names (my_widgets, handlers, ...) which made them overwrote each other's modules.
I put modules in a seperate folder for each target.