### PR TITLE
gtk_hl_dialog: bugfix

### DIFF
--- a/src/gtk-hl-dialog.f90
+++ b/src/gtk-hl-dialog.f90
@@ -341,7 +341,7 @@ contains
           cptr(i) = c_loc(credit(1))
           nullify(credit)
        end do
-       cptr(size(authors)+1) = c_null_ptr
+       cptr(size(documenters)+1) = c_null_ptr
        call gtk_about_dialog_set_documenters(about, cptr)
        deallocate(cptr)
     end if
@@ -354,7 +354,7 @@ contains
           cptr(i) = c_loc(credit(1))
           nullify(credit)
        end do
-       cptr(size(authors)+1) = c_null_ptr
+       cptr(size(artists)+1) = c_null_ptr
        call gtk_about_dialog_set_artists(about, cptr)
        deallocate(cptr)
     end if


### PR DESCRIPTION
Hi,
please pull my little bug fix of the hl_gtk_about_dialog_new function:
if providing artists or documenters, the cptr length was calculated from the numbers of author list.
Thanks for your amazing work :)