### PR TITLE
GValue size

### DIFF
--- a/src/gtk-sup.f90
+++ b/src/gtk-sup.f90
@@ -127,11 +127,11 @@ module gtk_sup
      type(c_ptr) :: p0=C_NULL_PTR, p1=C_NULL_PTR, p2=C_NULL_PTR
   end type gtktreeiter
 
-  ! Define a spacemaker for GValue It's 24 bytes on 64 bit & 20 on 32,
-  ! i.e. one long and 2 64-bit integers
+  ! Define a spacemaker for GValue It's 24 bytes on 64 bit, thus
+  ! 3 64-bit integers
+  ! 
   type, bind(c) :: gvalue
-     integer(kind=c_long) :: il = 0
-     integer(kind=c_int64_t), dimension(2) :: i64 = (/0, 0/)
+     integer(kind=c_int64_t), dimension(3) :: i64 = (/0, 0, 0/)
   end type gvalue
 
   ! Define a GtkTextIter (this has to be pre-allocated in the calls)
@@ -452,8 +452,8 @@ contains
     !
     ! GVAL: gvalue: required: The GValue to clear.
     !-
-    gval%il=0
-    gval%i64=(/0,0/)
+    
+    gval%i64 = [0, 0, 0]
   end subroutine clear_gvalue
 
   ! Some string conversion routines


### PR DESCRIPTION
Hi @vmagnin,

i'm using msys2 for my project. I found that all example list projects crashed with segfault. 
The problem is, that GValue is always 24 bytes on 64 bit, but c_long must not be 8 bytes (only 4 under windows).
I'm not quite sure, if this patch is the correct solution, but it works now under windows and linux.

Cheers,
Florian