### PR TITLE
gtk-fortran with gfortran 15

### DIFF
--- a/src/gtk-hl-dialog.f90
+++ b/src/gtk-hl-dialog.f90
@@ -277,13 +277,13 @@ contains
     if (present(logo)) call gtk_about_dialog_set_logo(about, logo)
 
     if (present(name)) then
-       call f_c_string(name, string)
+       call convert_f_string(name, string)
        call gtk_about_dialog_set_program_name(about, string)
        deallocate(string)
     end if
 
     if (present(license)) then
-       call f_c_string(license, string)
+       call convert_f_string(license, string)
        call gtk_about_dialog_set_license(about, string)
        deallocate(string)
     else if (present(license_type)) then
@@ -291,32 +291,32 @@ contains
     end if
 
     if (present(comments)) then
-       call f_c_string(comments, string)
+       call convert_f_string(comments, string)
        call gtk_about_dialog_set_comments(about, string)
        deallocate(string)
     end if
     if (present(website)) then
-       call f_c_string(website, string)
+       call convert_f_string(website, string)
        call gtk_about_dialog_set_website(about, string)
        deallocate(string)
     end if
     if (present(website_label)) then
-       call f_c_string(website_label, string)
+       call convert_f_string(website_label, string)
        call gtk_about_dialog_set_website_label(about, string)
        deallocate(string)
     end if
     if (present(translators)) then
-       call f_c_string(translators, string)
+       call convert_f_string(translators, string)
        call gtk_about_dialog_set_translator_credits(about, string)
        deallocate(string)
     end if
     if (present(copyright)) then
-       call f_c_string(copyright, string)
+       call convert_f_string(copyright, string)
        call gtk_about_dialog_set_copyright(about, string)
        deallocate(string)
     end if
     if (present(version)) then
-       call f_c_string(version, string)
+       call convert_f_string(version, string)
        call gtk_about_dialog_set_version(about, string)
        deallocate(string)
     end if
@@ -324,7 +324,7 @@ contains
     if (present(authors)) then
        allocate(cptr(size(authors)+1))
        do i = 1, size(authors)
-          call f_c_string(authors(i), string)
+          call convert_f_string(authors(i), string)
           allocate(credit(size(string)))
           credit(:) = string(:)
           cptr(i) = c_loc(credit(1))
@@ -337,7 +337,7 @@ contains
     if (present(documenters)) then
        allocate(cptr(size(documenters)+1))
        do i = 1, size(documenters)
-          call f_c_string(documenters(i), string)
+          call convert_f_string(documenters(i), string)
           allocate(credit(size(string)))
           credit(:) = string(:)
           cptr(i) = c_loc(credit(1))
@@ -350,7 +350,7 @@ contains
     if (present(artists)) then
        allocate(cptr(size(artists)+1))
        do i = 1, size(artists)
-          call f_c_string(artists(i), string)
+          call convert_f_string(artists(i), string)
           allocate(credit(size(string)))
           credit(:) = string(:)
           cptr(i) = c_loc(credit(1))
@@ -409,13 +409,13 @@ contains
          & comments = &
          &"The gtk-fortran project aims to offer scientists programming "//&
          &"in Fortran a cross-platform library to build Graphical User "//&
-         &"Interfaces (GUI)."//c_new_line// & 
+         &"Interfaces (GUI)."//c_new_line// &
          &"Gtk-fortran is a partial GTK / Fortran binding 100% written "//&
          &"in Fortran, thanks to the ISO_C_BINDING module for "//&
          &"interoperability between C and Fortran, which is a part of the "//&
          &"Fortran 2003 standard. Gtk-Fortran also provides a number of "//&
          &"'high-level' interfaces to common widgets."//&
-         &c_new_line//c_new_line// & 
+         &c_new_line//c_new_line// &
          &"GTK is a free software cross-platform graphical library "//&
          &"available for Linux, Unix, Windows and MacOs X."//C_NULL_CHAR, &
          & website="https://github.com/jerryd/gtk-fortran/wiki"//C_NULL_CHAR,&

--- a/src/gtk-sup.f90
+++ b/src/gtk-sup.f90
@@ -129,13 +129,13 @@ module gtk_sup
 
   ! Define a spacemaker for GValue It's 24 bytes on 64 bit, thus
   ! 3 64-bit integers
-  ! 
+  !
   type, bind(c) :: gvalue
      integer(kind=c_int64_t), dimension(3) :: i64 = (/0, 0, 0/)
   end type gvalue
 
   ! Define a GtkTextIter (this has to be pre-allocated in the calls)
-  type, bind(c) :: gtktextiter 
+  type, bind(c) :: gtktextiter
      type(c_ptr) :: d1, d2
      integer(kind=c_int) :: d3, d4, d5, d6, d7, d8
      type(c_ptr) :: d9, d10
@@ -390,11 +390,12 @@ module gtk_sup
      module procedure convert_c_string_array_cptr
   end interface c_f_string
 
-  interface f_c_string
-     module procedure convert_f_string_a
-     module procedure convert_f_string_aa
-     module procedure convert_f_string_s
-  end interface f_c_string
+! remove this interface as it conflicts with the one in the newest iso_c_binding
+!   interface f_c_string
+!      module procedure convert_f_string_a
+!      module procedure convert_f_string_aa
+!      module procedure convert_f_string_s
+!   end interface f_c_string
 
   interface convert_f_string
      module procedure convert_f_string_a
@@ -408,8 +409,8 @@ module gtk_sup
      module procedure f_c_logical1
   end interface f_c_logical
 
-  ! String conversion routines below lazily use the C std library function 
-  ! strlen.  If this is not available for some bizarre reason, then a 
+  ! String conversion routines below lazily use the C std library function
+  ! strlen.  If this is not available for some bizarre reason, then a
   ! simple index of the null character will suffice.
   ! Contributed by Ian Harvey, 2014.
   interface
@@ -452,7 +453,7 @@ contains
     !
     ! GVAL: gvalue: required: The GValue to clear.
     !-
-    
+
     gval%i64 = [0, 0, 0]
   end subroutine clear_gvalue
 
@@ -521,21 +522,21 @@ contains
 !    character(kind=c_char), pointer :: f_array(:)
 !
 !    call c_f_pointer(the_ptr, f_array, [strlen(the_ptr)])
-!    ! Here we rely on sequence association.  f_array is an array expression 
-!    ! (one that happens to be an array designator), so it designates an 
-!    ! array element sequence of all the elements of the array.  That array 
-!    ! element sequence is then associated with an array of different length 
+!    ! Here we rely on sequence association.  f_array is an array expression
+!    ! (one that happens to be an array designator), so it designates an
+!    ! array element sequence of all the elements of the array.  That array
+!    ! element sequence is then associated with an array of different length
 !    ! (but same total number of characters) inside do_association.
 !    call do_association(size(f_array), f_array, f_string)
 !  end subroutine c_f_string_ptr
 
   ! Worker routine for c_f_string_ptr
   !
-  ! It is processor dependent whether pointers associated with the actual 
-  ! argument are associated with the dummy argument inside the procedure.  
-  ! It is similarly processor dependent whether pointers associated with a 
-  ! dummy argument remain associated after the procedure exits.  But in 
-  ! F2003, this is the only way.  In F2008 things are a little better.  In 
+  ! It is processor dependent whether pointers associated with the actual
+  ! argument are associated with the dummy argument inside the procedure.
+  ! It is similarly processor dependent whether pointers associated with a
+  ! dummy argument remain associated after the procedure exits.  But in
+  ! F2003, this is the only way.  In F2008 things are a little better.  In
   ! F201X they are probably quite ok.
 !  subroutine do_association(l, str, f_string)
 !    integer, intent(in) :: l
@@ -740,7 +741,7 @@ contains
     allocate(lfstr(nfstr))
     lfstr = len_trim(f_string)
 
-    lcstr = sum(lfstr) 
+    lcstr = sum(lfstr)
     do i = 1, nfstr-1
        if (lfstr(i) == 0) then
           lcstr = lcstr+1
@@ -785,13 +786,13 @@ contains
          & dimension(:), allocatable :: length
 
     ! Convert a fortran string array into an array of null-terminated
-    ! C strings. 
+    ! C strings.
     !
     ! F_STRING: f_string: required: The fortran string to convert
     ! TEXTPR: string: required: A C type string, (allocatable) 2-D
     ! 	fortran array.
     ! LENGTH: c_int: optional: An allocatable integer array to return
-    ! the lengths of the strings.	
+    ! the lengths of the strings.
     !-
 
     integer :: lcstr, i, j, nfstr
@@ -916,7 +917,7 @@ contains
     logical :: is_UNIX_OS
     character(len=512) :: path
 
-    ! Returns .true. if the OS is of the UNIX type. On a Windows system, it 
+    ! Returns .true. if the OS is of the UNIX type. On a Windows system, it
     ! will return .false. because an absolute path can not begin by a /
     !-
 


### PR DESCRIPTION
Hi @vmagnin,

i just realised that gtk-fortran isn't compiling with the new gfortran 15, because gfortran is using new iso_c_binding as part of Fortran 2023. Included is a function (f_c_string) which converts fortran strings to c strings. This function is in conflict with the interface defined in the `gtk-sup.f90`. 
As far as i can see, there is only one module (gtk-hl-dialog.f90) using this subroutine. Thus, i switched to the second interface defined in `gtk-sup.f90` as well (convert_f_string) and removed the f_c_string interface.

If you don't like this, you could also add `-std=f2018` as compiler flag for the moment.

Kind regards :)
Florian