### PR TITLE
Fix Windows ifx build

### DIFF
--- a/cmake/DefaultFlags.cmake
+++ b/cmake/DefaultFlags.cmake
@@ -57,17 +57,31 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   )
 elseif((CMAKE_Fortran_COMPILER_ID STREQUAL "Intel") OR (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM"))
   # ifort and ifx compilers (OneAPI):
-  set(
-    CMAKE_Fortran_FLAGS_RELEASE_INIT
-    "-O3"
-  )
-  set(
-    CMAKE_Fortran_FLAGS_DEBUG_INIT
-    "-g"
-    "-O0"
-    "-warn all"
-    "-warn nounused"
-  )
+  if(WIN32)
+    set(
+      CMAKE_Fortran_FLAGS_RELEASE_INIT
+      "/O2"
+    )
+    set(
+      CMAKE_Fortran_FLAGS_DEBUG_INIT
+      "/debug:full"
+      "/Od"
+      "/warn:all"
+      "/warn:nounused"
+    )
+  else()
+    set(
+      CMAKE_Fortran_FLAGS_RELEASE_INIT
+      "-O3"
+    )
+    set(
+      CMAKE_Fortran_FLAGS_DEBUG_INIT
+      "-g"
+      "-O0"
+      "-warn all"
+      "-warn nounused"
+    )
+  endif()
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
   # -fPIC is necessary to avoid a linking error
   set(


### PR DESCRIPTION
 Title:
  Fix Windows ifx build flags

  Body:

  ## Summary

  This updates the Windows Intel compiler flags in `cmake/DefaultFlags.cmake` so `gtk-fortran` can configure and build
  with `ifx` in MSVC-like mode.

  ## Problem

  On Windows, CMake identifies `ifx` as `IntelLLVM` with MSVC-like command-line syntax. The existing `Intel/IntelLLVM`
  flag block used Unix-style flags such as:

  - `-g`
  - `-O0`
  - `-warn all`
  - `-warn nounused`

  During CMake’s initial compiler checks, those were translated into invalid MSVC-style options for `ifx`, causing
  failures such as:

  - `ifx: command line error: option '/g' is ambiguous`

  This prevented configuration from completing.

  ## Fix

  For `Intel` / `IntelLLVM` on `WIN32`, use Windows-style flags instead:

  - Release: `/O2`
  - Debug:
    - `/debug:full`
    - `/Od`
    - `/warn:all`
    - `/warn:nounused`

  Unix-style Intel flags are preserved for non-Windows builds.

  ## Verification

  Tested on Windows with:

  ```powershell
  cmake .. -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DPKG_CONFIG_EXECUTABLE=C:\gtk-
  build\gtk\x64\release\bin\pkg-config.exe -DCMAKE_INSTALL_PREFIX=C:\gtk-build\gtk\x64\release
  nmake
  nmake install

  Compiler:

  - ifx (IntelLLVM, MSVC-like mode)

  Result:

  - configuration completed successfully
  - full build completed successfully
  - install completed successfully
  - PLplot examples in plplot/ also built successfully